### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dardin88/SorrentoMarina/security/code-scanning/1](https://github.com/dardin88/SorrentoMarina/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum required permissions for the workflow. Based on the provided workflow, the actions used (e.g., `actions/checkout`, `actions/setup-java`, and `maven-dependency-submission-action`) only require read access to the repository contents. Therefore, we will set `contents: read` as the permission.

The `permissions` block will be added immediately after the `name` field (line 9) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
